### PR TITLE
Feature/strong parameters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'pg'
 gem 'seed-fu', '~> 2.3.3'
 gem 'spreadsheet_on_rails', '~> 1.0.0'
 gem 'mysql2', '~> 0.3.10', require: false
+gem 'strong_parameters'
 
 #Assets
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,11 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
+    strong_parameters (0.2.3)
+      actionpack (~> 3.0)
+      activemodel (~> 3.0)
+      activesupport (~> 3.0)
+      railties (~> 3.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     therubyracer (0.9.10)
@@ -344,6 +349,7 @@ DEPENDENCIES
   spreadsheet_on_rails (~> 1.0.0)
   spring
   spring-commands-cucumber
+  strong_parameters
   term-ansicolor
   therubyracer (~> 0.9.2)
   timecop (= 0.3.4)

--- a/app/controllers/availabilities_controller.rb
+++ b/app/controllers/availabilities_controller.rb
@@ -21,11 +21,11 @@ class AvailabilitiesController < ApplicationController
   end
 
   def new
-    @availability = Availability.new(:staff_id => @staff)
+    @availability = Availability.new
   end
 
   def create
-    @availability = Availability.new(params[:availability])
+    @availability = Availability.new(availability_params)
     @availability.staff = @staff
     @availability.edited_by_administrator = admin?
     @availability.changing_own_availability = changing_own_availability?
@@ -45,7 +45,7 @@ class AvailabilitiesController < ApplicationController
   def update
     @availability.edited_by_administrator = admin?
     @availability.changing_own_availability = changing_own_availability?
-    if @availability.update_attributes(params[:availability])
+    if @availability.update_attributes(availability_params)
       flash[:notice] = 'Availability was successfully updated.'
       redirect_to(staff_availabilities_path(@availability.staff, :start_date => @availability.start_date))
     else
@@ -78,6 +78,10 @@ class AvailabilitiesController < ApplicationController
   end
 
   private
+
+  def availability_params
+    params.require(:availability).permit(*Availability.strong_attributes)
+  end
 
   def parse_start_date_from_params_or_now
     @time = (Chronic.parse(params[:start_date]) || Time.now).beginning_of_week

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -17,7 +17,7 @@ class EventsController < ApplicationController
   end
 
   def new
-    @event = Event.new(:venue_id => params[:venue_id])
+    @event = Event.new(venue_id: params[:venue_id])
   end
 
   def edit
@@ -25,7 +25,7 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = Event.new(params[:event])
+    @event = Event.new(event_params)
     @event.organiser_id = current_staff.id
 
     if @event.save
@@ -42,7 +42,7 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
     @event.approver_id = current_staff.id if params[:event][:state] && params[:event][:state] == 'approved'
 
-    if @event.update_attributes(params[:event])
+    if @event.update_attributes(event_params)
       flash[:notice] = 'Event was successfully updated.'
       redirect_to(@event)
     else
@@ -136,6 +136,10 @@ class EventsController < ApplicationController
   end
 
   private
+
+  def event_params
+    EventService.get_strong_attributes(params)
+  end
 
   def redirect_staff_unless_event_approved
     # By default, Event.find will exclude cancelled and deleted

--- a/app/controllers/staff_controller.rb
+++ b/app/controllers/staff_controller.rb
@@ -26,7 +26,7 @@ class StaffController < ApplicationController
   end
 
   def create
-    @staff = Staff.new(params[:staff])
+    @staff = Staff.new(staff_params)
 
     if @staff.save
       flash[:notice] = 'Staff was successfully created. '
@@ -45,7 +45,7 @@ class StaffController < ApplicationController
     @staff = staff_from_id_else_current
     @staff.skip_current_password = admin? # skips current password check
 
-    if @staff.update_attributes(params[:staff])
+    if @staff.update_attributes(staff_params)
       flash[:notice] = 'Staff was successfully updated.'
       redirect_to(@staff)
     else
@@ -95,6 +95,15 @@ class StaffController < ApplicationController
   end
 
   private
+
+  def staff_password_params
+    [:password, :password_confirmation, :current_password]
+  end
+
+  def staff_params
+    params.require(:staff)
+      .permit(*(Staff.strong_attributes + staff_password_params))
+  end
 
   def current_staff_can_view_profile
     unless admin? || staff_from_id_else_current == current_staff

--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -13,6 +13,8 @@
 #
 
 class Availability < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+
   belongs_to :staff
 
   validates_presence_of :staff_id, :start_date, :end_date
@@ -51,6 +53,34 @@ class Availability < ActiveRecord::Base
     "(availabilities.start_date <= :start_date AND availabilities.end_date >= :end_date)",
     { :start_date => start_date.to_date.to_s, :end_date => end_date.to_date.to_s }
   ] } }
+
+
+  def self.strong_attributes
+    [
+      :start_date,
+      :end_date,
+      :notification_comment,
+      :admin_locked,
+      :ignore_availability_conflicts,
+      :notification_comment,
+      :edited_by_administrator,
+      :changing_own_availability,
+      :split_date,
+      hours: {
+          all: hours_attributes,
+          mon: hours_attributes,
+          tue: hours_attributes,
+          wed: hours_attributes,
+          thu: hours_attributes,
+          fri: hours_attributes,
+          sat: hours_attributes,
+          sun: hours_attributes}
+    ]
+  end
+
+  def self.hours_attributes
+    [:start, :finish, :comment]
+  end
 
   # WARNING
   # Split day event availability detection is still incomplete

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,8 @@
 #
 
 class Event < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+
   has_many :rosterings, :dependent => :destroy
   has_many :staff, :through => :rosterings
   has_many :email_logs, :dependent => :destroy
@@ -127,6 +129,26 @@ class Event < ActiveRecord::Base
     define_method "#{type}_staff_for" do |role|
       rosterings.send(type.to_sym).with_role(role)
     end
+  end
+
+  def self.strong_attributes
+    [
+      :allow_past_events,
+      :cancel_unavailable_staff,
+      :clear_unconfirmed_rosterings,
+      :description,
+      :end_datetime,
+      :ignore_event_conflicts,
+      :name,
+      :recurring,
+      :roles,
+      :schedule_id,
+      :skip_notification_email,
+      :start_datetime,
+      :state,
+      :venue_id
+      # In EventService class, all numeric key values are permitted for roles
+    ]
   end
 
   # Gets run by a cron job after system reboot

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -20,6 +20,8 @@
 #
 
 class Staff < ActiveRecord::Base
+  include ActiveModel::ForbiddenAttributesProtection
+
   has_many :staff_roles
   has_many :roles, :through => :staff_roles
   has_many :staff_details
@@ -56,6 +58,20 @@ class Staff < ActiveRecord::Base
   scope :administrators, :conditions => { :staff_type => 'admin' }
   scope :members, :conditions => { :staff_type => 'staff' }
 
+  def self.strong_attributes
+    [
+      :username,
+      :staff_type,
+      :email,
+      :full_name,
+      :start_date,
+      :admin_notes,
+      :password,
+      :password_confirmation,
+      contact_details: %w(1 2 3 4 5),
+      role_ids: []
+    ]
+  end
 
   def self.available_for(event)
     all.select { |staff| staff.available_for?(event) }
@@ -244,4 +260,6 @@ class Staff < ActiveRecord::Base
   def send_notifying_email
     Notifier.deliver_email_or_pdf_of(:staff_account_creation, self)
   end
+
+
 end

--- a/app/services/event_service.rb
+++ b/app/services/event_service.rb
@@ -1,0 +1,17 @@
+class EventService
+  def self.get_strong_attributes(params)
+    params.require(:event).permit(
+      *(Event.strong_attributes + numeric_role_keys(params)))
+  end
+
+  private
+
+  def self.numeric_role_keys(params)
+    role_keys = params.require(:event).fetch(:roles, {}).keys
+
+    [{
+      roles: role_keys.select { |key| key =~ /^[0-9]+$/ }
+    }]
+  end
+
+end

--- a/features/availability.feature
+++ b/features/availability.feature
@@ -68,6 +68,7 @@ Feature: Availability
     Then I should see "Availability was successfully updated."
 
   Scenario: Editing Availability locked by an admin, then unlocked
+    Given it is currently next wednesday
     Given I am logged in as "admin"
     And "Gerry" is available from 2 day ago till 2 days from now
     When I go to edit the current availability of "Gerry"

--- a/features/step_definitions/events_steps.rb
+++ b/features/step_definitions/events_steps.rb
@@ -20,10 +20,16 @@ Given /^that event has not started$/ do
   # do nothing, find_or_create_event makes events that have not started
 end
 
+def update_event(attributes)
+  params = ActionController::Parameters.new(attributes)
+
+  @event.update_attributes!(params.permit(*Event.strong_attributes))
+end
+
 Given /^that event starts in ([^\"]*)$/ do |time|
   reload_event
   time = parse_time(time)
-  @event.update_attributes!({
+  update_event({
     :start_datetime => time,
     :end_datetime => time + 1.day,
     :allow_past_events => true,
@@ -34,7 +40,7 @@ end
 Given /^that event ends in ([^\"]*)$/ do |time|
   reload_event
   time = parse_time(time)
-  @event.update_attributes!({
+  update_event( attributes = {
     :end_datetime => time,
     :allow_past_events => true,
     :ignore_event_conflicts => true
@@ -43,7 +49,7 @@ end
 
 Given /^that event is in progress$/ do
   reload_event
-  @event.update_attributes!({
+  update_event({
     :start_datetime => 1.day.ago,
     :end_datetime => 1.day.from_now,
     :allow_past_events => true
@@ -53,7 +59,7 @@ end
 Given /^that event finished ([^\"]*)$/ do |time|
   reload_event
   time = parse_time(time)
-  @event.update_attributes!({
+  update_event({
     :start_datetime => (time - 1.minute),
     :end_datetime => time,
     :allow_past_events => true


### PR DESCRIPTION
Here is a pull request to enable the use of strong parameters for controllers. All controllers that don't use active_scaffold generated controller methods now have a *_params method that checks the model for a list of parameters to mass update.

The active_scaffold based controllers don't need the extra method because active_scaffold queries the `config.columns` config value to apply parameters to fields one-by-one. You could say active_scaffold has it's own strong_attribute protection.

How does it look?