### PR TITLE
Feature/fix dst event deletion

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -217,7 +217,7 @@ class Event < ActiveRecord::Base
   end
 
   def finished_a_month_ago?
-    end_datetime < 1.month.ago
+    end_datetime.utc < DateTime.now.utc - 1.month
   end
 
   def editable?

--- a/features/events.feature
+++ b/features/events.feature
@@ -74,9 +74,19 @@ Feature: Events
     When I go to the past events list
     Then I should see "Special Day"
 
-  Scenario: Delete Event a month after finished
-    Given an event "Special Day" exists at "Civic Square"
-    And that event finished 1 month ago
+  Scenario: Delete Event a month after finished without DST adjustment
+    Given it is currently 9th July 2016
+    And an event "Special Day" exists at "Civic Square"
+    And that event finished 32 days ago
+    When I go to delete the event
+    And I press "Yes, I'm sure."
+    Then I should see "Event was successfully destroyed."
+    Then I should not see "Special Day"
+
+  Scenario: Delete Event a month after finished with DST adjustment
+    Given it is currently 9th November 2016
+    And an event "Special Day" exists at "Civic Square"
+    And that event finished 32 days ago
     When I go to delete the event
     And I press "Yes, I'm sure."
     Then I should see "Event was successfully destroyed."


### PR DESCRIPTION
This pull request fixes a minor bug that broke tests when they are run within a month of DST changes. The actual symptoms of the bug were that you would have to wait one month and two hours before being able to delete an event. Not a big issue, but I believe it's fixed now just in case.

The real issue was that the tests were failing, so I made them cover cases with DST changeover and without. I also made the tests a little less brittle by allowing 32 days to pass after the end of the event and the day it is deleted. (Any comments on this approach are welcome.)